### PR TITLE
Fix methods slide, length is not a method

### DIFF
--- a/class2.html
+++ b/class2.html
@@ -411,15 +411,14 @@ var img = document.getElementById('mainpicture');
         <section>
           <h3>Methods</h3>
           <ul>
-            <li class = "fragment">Methods are special functions</li>
+            <li class = "fragment">Methods are functions that are associated with an object</li>
             <li class = "fragment">The affect or return a value for a specific object</li>
             <li class = "fragment">Used with dot notation</li>
           </ul>
           <div class = "fragment">
             Previously seen example:
             <pre><code contenteditable class = "javascript">
-  var candy = ['Gummy Bears', 'Sour Patch Kids', 'Swedish Fish'];
-  var length = candy.length;
+            var img = document.getElementById('mainpicture');
             </code></pre>
           </div>
         </section>


### PR DESCRIPTION
`.length` is not a method, but an attribute of an array object (which is itself a form of an Object). Methods are not special functions, but functions that are associated with an object (Object)

https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/Array/length
