### PR TITLE
Fix typos

### DIFF
--- a/class1.html
+++ b/class1.html
@@ -253,7 +253,7 @@
             </code></pre>
           </div>
           <div class = "fragment">
-            In nerd speak, JavaScript variables are "loosely typed". You don't know the kind of value a variable will have until you assign it.
+            In nerd speak, JavaScript variables are "loosely typed." You don't know the kind of value a variable will have until you assign it.
           </div>
         </section>
         
@@ -313,7 +313,7 @@
             <pre><code contenteditable class ="javascript">
 var name = "Mitch";
 var dinosaur = "Stegosaurus";
-var sentence = "My dinosaur is a " + dinosaur + ". It's name is " + name + ".";
+var sentence = "My dinosaur is a " + dinosaur + ". Its name is " + name + ".";
             </code></pre>
           </div>
         </section>
@@ -353,7 +353,7 @@ var sentence = "My dinosaur is a " + dinosaur + ". It's name is " + name + ".";
         
         <section>
           <h3>Let's Develop It</h3>
-          <p>Life time supply calculator</p>
+          <p>Lifetime supply calculator</p>
           <p>Ever wonder how much a lifetime supply of your favorite snack or drink is?</p>
           <ul>
             <li>Store your age in a variable</li>
@@ -552,7 +552,7 @@ if (age >= 35) {
         <!-- Functions cont.-->
         <section>
           <h3>Variable Scope</h3>
-          <p class = "fragment">JavaScript have "function scope". They are visible in the function where they are defined</p>
+          <p class = "fragment">JavaScript variables have "function scope." They are visible in the function where they are defined</p>
           <div class = "fragment">
             A variable with "local" scope:
          <pre><code contenteditable class ="javascript">
@@ -569,7 +569,7 @@ if (age >= 35) {
         <!-- Functions cont.-->
         <section>
           <h3>Variable Scope</h3>
-          <p class = "fragment">JavaScript have "function scope". They are visible in the function where they are defined</p>
+          <p class = "fragment">JavaScript variables have "function scope." They are visible in the function where they are defined</p>
           <div class = "fragment">
             A variable with "global" scope:
          <pre><code contenteditable class ="javascript">


### PR DESCRIPTION
- Punctuation goes inside quotation marks in the U.S.
- Changed to "its" (because "it's" means "it is"
- Added missing word 'variable'
